### PR TITLE
Add logarithmic volume control

### DIFF
--- a/src/audio/create-audio-player.ts
+++ b/src/audio/create-audio-player.ts
@@ -157,7 +157,8 @@ export const useAudioPlayer = (): void => {
   }
 
   createEffect(() => {
-    audio.volume = playerState.volume / 100
+    const k = 0.5 //value for adjusting the curve
+    audio.volume = Math.pow(playerState.volume / 100, k)
     audio.muted = playerState.isMuted
     audio.loop = playerState.repeat === RepeatState.ONCE
   })

--- a/src/components/shared-player-components/volume/volume-panel.tsx
+++ b/src/components/shared-player-components/volume/volume-panel.tsx
@@ -15,11 +15,10 @@ export const VolumePanel: VoidComponent = () => {
     const inputEl = e.target as HTMLInputElement
     const parsedValue = parseInt(inputEl.value, 10)
     
-    const maxVolume = 100 
     // This is probably not needed, but it doen't hurt.
-    const value = Number.isInteger(parsedValue) ? parsedValue : maxVolume
+    const value = Number.isInteger(parsedValue) ? parsedValue : 100
     
-    playerActions.setVolume(powValue)
+    playerActions.setVolume(value)
   }
 
   return (

--- a/src/components/shared-player-components/volume/volume-panel.tsx
+++ b/src/components/shared-player-components/volume/volume-panel.tsx
@@ -13,11 +13,17 @@ export const VolumePanel: VoidComponent = () => {
 
   const onVolumeInputHandler = (e: InputEvent) => {
     const inputEl = e.target as HTMLInputElement
-    const parsedValue = parseInt(inputEl.value, 10)
+    const parsedValue = Math.pow(1, 2)
+    
+    const maxValue = 100 // value for normalizing
     // This is probably not needed, but it doen't hurt.
-    const value = Number.isInteger(parsedValue) ? parsedValue : 100
-
-    playerActions.setVolume(value)
+    const value = Number.isInteger(parsedValue) ? parsedValue : maxValue
+    
+    const k = 0.5 //value for adjusting the curve
+    const normalizedInput = inputVolume / maxVolume;
+    const powValue = maxVolume * Math.pow(normalizedInput, k)
+    
+    playerActions.setVolume(powValue)
   }
 
   return (

--- a/src/components/shared-player-components/volume/volume-panel.tsx
+++ b/src/components/shared-player-components/volume/volume-panel.tsx
@@ -13,7 +13,7 @@ export const VolumePanel: VoidComponent = () => {
 
   const onVolumeInputHandler = (e: InputEvent) => {
     const inputEl = e.target as HTMLInputElement
-    const parsedValue = parseInt(inputEl.value, 10)
+    const parsedValue = parseFloat(inputEl.value)
     
     const maxValue = 100 // value for normalizing
     // This is probably not needed, but it doen't hurt.

--- a/src/components/shared-player-components/volume/volume-panel.tsx
+++ b/src/components/shared-player-components/volume/volume-panel.tsx
@@ -13,15 +13,11 @@ export const VolumePanel: VoidComponent = () => {
 
   const onVolumeInputHandler = (e: InputEvent) => {
     const inputEl = e.target as HTMLInputElement
-    const parsedValue = parseFloat(inputEl.value)
+    const parsedValue = parseInt(inputEl.value, 10)
     
-    const maxVolume = 100 // value for normalizing
+    const maxVolume = 100 
     // This is probably not needed, but it doen't hurt.
     const value = Number.isInteger(parsedValue) ? parsedValue : maxVolume
-    
-    const k = 0.5 //value for adjusting the curve
-    const normalizedValue = value / maxVolume;
-    const powValue = maxVolume * Math.pow(normalizedValue, k)
     
     playerActions.setVolume(powValue)
   }

--- a/src/components/shared-player-components/volume/volume-panel.tsx
+++ b/src/components/shared-player-components/volume/volume-panel.tsx
@@ -20,8 +20,8 @@ export const VolumePanel: VoidComponent = () => {
     const value = Number.isInteger(parsedValue) ? parsedValue : maxValue
     
     const k = 0.5 //value for adjusting the curve
-    const normalizedInput = inputVolume / maxVolume;
-    const powValue = maxVolume * Math.pow(normalizedInput, k)
+    const normalizedValue = value / maxVolume;
+    const powValue = maxVolume * Math.pow(normalizedValue, k)
     
     playerActions.setVolume(powValue)
   }

--- a/src/components/shared-player-components/volume/volume-panel.tsx
+++ b/src/components/shared-player-components/volume/volume-panel.tsx
@@ -13,7 +13,7 @@ export const VolumePanel: VoidComponent = () => {
 
   const onVolumeInputHandler = (e: InputEvent) => {
     const inputEl = e.target as HTMLInputElement
-    const parsedValue = Math.pow(1, 2)
+    const parsedValue = parseInt(inputEl.value, 10)
     
     const maxValue = 100 // value for normalizing
     // This is probably not needed, but it doen't hurt.

--- a/src/components/shared-player-components/volume/volume-panel.tsx
+++ b/src/components/shared-player-components/volume/volume-panel.tsx
@@ -15,9 +15,9 @@ export const VolumePanel: VoidComponent = () => {
     const inputEl = e.target as HTMLInputElement
     const parsedValue = parseFloat(inputEl.value)
     
-    const maxValue = 100 // value for normalizing
+    const maxVolume = 100 // value for normalizing
     // This is probably not needed, but it doen't hurt.
-    const value = Number.isInteger(parsedValue) ? parsedValue : maxValue
+    const value = Number.isInteger(parsedValue) ? parsedValue : maxVolume
     
     const k = 0.5 //value for adjusting the curve
     const normalizedValue = value / maxVolume;


### PR DESCRIPTION
Creating a volume control that corresponds well with human perception involves applying a logarithmic function. This is because human perception of volume is roughly logarithmic rather than linear.

I had this in my old audio-station project. But I prefer using PWA Snae now! It was unexpectedly good! Thx.

I don't have time to test it, since I am unfamilair with Typescript, but it should work since it is just a transformation of value to powValue. Feel free to refactor it.

